### PR TITLE
Feature/targeted build

### DIFF
--- a/test/test_build.py
+++ b/test/test_build.py
@@ -1,5 +1,6 @@
 import unittest
 from functools import partial
+import math
 from artifax import build
 from artifax.exceptions import UnresolvedDependencyError
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -142,8 +142,19 @@ class ModelTest(unittest.TestCase):
             'exp': lambda: Exp().counter + 4
         })
         result = afx.build(target='b')
+        # exp = 5, b = 42^5
+        self.assertEqual(result, 130691232)
+        # C should not have been instantiated
+        self.assertEqual(C.counter, 0)
+        result = afx.build(target='b')
+        # no updates, all nodes are fresh
         self.assertEqual(result, 130691232)
         self.assertEqual(C.counter, 0)
+        # trigger new exp: 6
+        result = afx.build(target='exp')
+        self.assertEqual(result(), 6)
+        _ = afx.build()
+        self.assertEqual(Exp.counter, 2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -126,5 +126,24 @@ class ModelTest(unittest.TestCase):
         self.assertGreater(index('msg'), index('greet'))
         self.assertGreater(index('msg'), index('A'))
 
+    def test_targeted_build(self):
+        class C:
+            counter = 0
+            def __init__(self):
+                C.counter += 1
+        class Exp:
+            counter = 0
+            def __init__(self):
+                Exp.counter += 1
+        afx = Artifax({
+            'a': 42,
+            'b': lambda a, exp: math.pow(a, exp()),
+            'c': lambda: C(),
+            'exp': lambda: Exp().counter + 4
+        })
+        result = afx.build(target='b')
+        self.assertEqual(result, 130691232)
+        self.assertEqual(C.counter, 0)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Enables builds that target a specific node by passing the node name as a parameter to the build method in the artifax class instance.

```python
from artifax import Artifax
afx = Artifax({
    'a': 42,
    'b': lambda a: 'Hello, {}'.format(a)
})
result = afx.build(target='b')
print(result) # prints "Hello, 42"
```