### PR TITLE
Drops character replacement in key names

### DIFF
--- a/artifax/builder.py
+++ b/artifax/builder.py
@@ -163,11 +163,10 @@ def _on_done(artifacts, graph, node, done, rem, value, apf=False, **kwargs):
 
 def _resolve(node, store, apf=False):
     value = store[node]
-    args = u.arglist(value)
+    keys = u.arglist(value)
     if isinstance(value, u.At):
-        args = value.args()
+        keys = value.args()
         value = value.value()
-    keys = [u.unescape(a) for a in args]
     args = [store[key] for key in keys if key in store]
     unresolved = [key for key in keys if key not in store]
     if not apf and unresolved:

--- a/artifax/models.py
+++ b/artifax/models.py
@@ -31,76 +31,6 @@ class Artifax:
     like incremental builds and building of stale nodes only.
     """
 
-    class Result:
-        """The Result class acts as an augmented dictionary to
-        hold the artifax build products and any additional information
-        deemed necessary or interesting."""
-
-        def __init__(self, *args, **kwargs):
-            self._data = {}
-            self.update(*args, **kwargs)
-
-        def __setitem__(self, key, item):
-            self._data[key] = item
-
-        def __getitem__(self, key):
-            return self._data[key]
-
-        def __repr__(self):
-            return repr(self._data)
-
-        def __len__(self):
-            return len(self._data)
-
-        def __delitem__(self, key):
-            del self._data[key]
-
-        def clear(self):
-            """Removes all items from result."""
-            return self._data.clear()
-
-        def copy(self):
-            """Returns a shallow copy of the result dictionary."""
-            return self._data.copy()
-
-        def has_key(self, k):
-            """Returns True if key k is part of the result and False otherwise."""
-            return k in self._data
-
-        def update(self, *args, **kwargs):
-            """R.update([E, ]**F) -> None.  Update R from dict/iterable E and F.
-            If E is present and has a .keys() method, then does:  for k in E: R[k] = E[k]
-            If E is present and lacks a .keys() method, then does:  for k, v in E: R[k] = v
-            In either case, this is followed by: for k in F:  R[k] = F[k]"""
-            return self._data.update(*args, **kwargs)
-
-        def keys(self):
-            """Returns a set-like object providing a view on D's keys."""
-            return self._data.keys()
-
-        def values(self):
-            """Returns an object providing a view on D's values."""
-            return self._data.values()
-
-        def items(self):
-            """Returns key, value pairs of data dictionary items."""
-            return self._data.items()
-
-        def pop(self, *args):
-            """pop(k, [,d]) -> v, remove specified key and return
-            the corresponding value. If key is not found, d is returned
-            if given, otherwise KeyError is raised"""
-            return self._data.pop(*args)
-
-        def __cmp__(self, dict_):
-            return self._data == dict_
-
-        def __contains__(self, item):
-            return item in self._data
-
-        def __iter__(self):
-            return iter(self._data)
-
     def __init__(self, dic=None, allow_partial_functions=False, **kwargs):
         if dic is None:
             dic = {}
@@ -108,7 +38,7 @@ class Artifax:
         self._artifacts = dic.copy()
         self._graph = None
         self._update_graph()
-        self._result = Artifax.Result()
+        self._result = {}
         self._stale = set(self._artifacts.keys())
         self._allow_partial_functions = allow_partial_functions
 

--- a/artifax/utils.py
+++ b/artifax/utils.py
@@ -12,18 +12,6 @@ __email__ = "blangeram@gmail.com"
 __license__ = "MIT"
 
 
-_REPLACES = {
-    "-": "_",
-}
-
-# make sure we can always undo a key replacement
-assert len(_REPLACES) == len({v: k for k, v in _REPLACES.items()})
-
-escape = lambda v: reduce(lambda s, k: s.replace(k, _REPLACES[k]), _REPLACES.keys(), v)
-unescape = lambda v: reduce(
-    lambda s, k: s.replace(_REPLACES[k], k), _REPLACES.keys(), v
-)
-
 arglist = lambda v: (
     getfullargspec(v).args if callable(v) else v.args() if isinstance(v, At) else []
 )
@@ -32,9 +20,7 @@ arglist = lambda v: (
 def to_graph(artifacts):
     """returns a graph representation of the given artifacts"""
     af_args = {k: arglist(v) for k, v in artifacts.items()}
-    return {
-        key: [k for k, v in af_args.items() if escape(key) in v] for key in artifacts
-    }
+    return {key: [k for k, v in af_args.items() if key in v] for key in artifacts}
 
 
 def topological_sort(graph):

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -16,7 +16,7 @@ def test_single_artifact_build():
 
 
 def test_artifact_immutability():
-    artifacts = {"a": 42, "b": lambda a: a ** 2}
+    artifacts = {"a": 42, "b": lambda a: a**2}
 
     results = build(artifacts, solver="async")
 
@@ -62,7 +62,7 @@ def test_sample_build():
 
 def test_partial_build():
     artifacts = {
-        "A": lambda x: x ** 2,
+        "A": lambda x: x**2,
         "B": lambda A, x: A(x),
         "C": lambda A, x: "A(4)-{} is equal to {}".format(x, A(4) - x),
     }

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -82,18 +82,6 @@ def test_build_with_partial_functions():
     assert isinstance(result["b"], partial)
 
 
-def test_special_keys():
-    artifacts = {
-        "key-with-dash": "a value",
-        "bang": lambda key_with_dash: "{}!".format(key_with_dash),
-        "_underscore_key": lambda bang: "_{}_".format(bang),
-    }
-    result = build(artifacts)
-    assert result["key-with-dash"], "a value"
-    assert result["bang"], "a value!"
-    assert result["_underscore_key"], "_a value!_"
-
-
 def test_at_constructor():
     def subtract(p, q):
         return p - q


### PR DESCRIPTION
This PR addresses issue #7 by removing the logic that attempted to establish dependencies to nodes that had dash characters in their names by replacing those for underscores.

This means this build will no longer succeed:

```python
artifacts = {
    "my-message": "hello world",
    "cool": lambda my_message: "{}!".format(my_message),
}
result = build(artifacts)  # UnresolvedDependencyError since `my_message` has not been seeded
```

If a node contains a dash character, any nodes that depend on it can make use of the `At` constructor:

```python
def bang(v):
    return f"{v}!"

afx = Artifax(
    cool=At("my-message", bang),
    **{
        "my-message": "hello world",
    }
)

print(afx.build(targets=["cool"]))  # prints "hello world!"
```