### PR TITLE
Fix artifax.utils.arglist to use inspect.signature instead of inspect.getfullargspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ dist/
 *.egg-info
 .vscode/
 venv*
+.venv
 pythonenv*/
 *.aux
 *.fdb_latexmk

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ artifacts = {
     'B': 7,
     'C': lambda: 10,
     'AB': lambda A, B: A*B,
-    'C-B': lambda B, C: C() - B,
+    'C-B': lambda B, C: C - B,
     'greeting': 'Hello',
     'message': lambda greeting, A: '{} World! The answer is {}.'.format(greeting, A)
 }
@@ -61,7 +61,7 @@ artifacts = {
     'B': 7,
     'C': lambda: 10,
     'AB': lambda A, B: A*B,
-    'C-B': lambda B, C: C() - B,
+    'C-B': lambda B, C: C - B,
     'greeting': 'Hello',
     'message': lambda greeting, A: '{} World! The answer is {}.'.format(greeting, A)
 }

--- a/artifax/builder.py
+++ b/artifax/builder.py
@@ -20,7 +20,7 @@ __license__ = "MIT"
 # pylint: disable=C0103
 _apply = lambda v, *args: (
     v(*args)
-    if callable(v) and args and len(u.arglist(v)) == len(args)
+    if callable(v) and args is not None and len(u.arglist(v)) == len(args)
     else partial(v, *args)
     if callable(v)
     else v

--- a/artifax/utils.py
+++ b/artifax/utils.py
@@ -3,7 +3,7 @@
 
 import os
 from functools import reduce
-from inspect import getfullargspec
+from inspect import signature
 
 from . import exceptions
 
@@ -25,7 +25,7 @@ unescape = lambda v: reduce(
 )
 
 arglist = lambda v: (
-    getfullargspec(v).args if callable(v) else v.args() if isinstance(v, At) else []
+    list(signature(v).parameters.keys()) if callable(v) else v.args() if isinstance(v, At) else []
 )
 
 

--- a/test/test_build.py
+++ b/test/test_build.py
@@ -21,7 +21,7 @@ class BuildTest(unittest.TestCase):
     def test_artifact_immutability(self):
         artifacts = {
             'a': lambda: 42,
-            'b': lambda a: a()**2
+            'b': lambda a: a**2
         }
 
         results = build(artifacts, solver='async')
@@ -46,13 +46,24 @@ class BuildTest(unittest.TestCase):
         for k in artifacts:
             self.assertEqual(result[k], artifacts[k])
 
+    def test_function_with_no_args_build(self):
+        artifacts = {
+            'a': 'a',
+            'thing': lambda a: a,
+            'other_thing': lambda: 'other_thing',
+        }
+        result = build(artifacts, solver='linear')
+        self.assertEqual(result['a'], 'a')
+        self.assertEqual(result['thing'], 'a')
+        self.assertEqual(result['other_thing'], 'other_thing')
+
     def test_sample_build(self):
         artifacts = {
             'A': 42,
             'B': lambda: 7,
             'C': lambda: 10,
-            'AB': lambda A, B: A + B(),
-            'C minus B': lambda B, C: C() - B(),
+            'AB': lambda A, B: A + B,
+            'C minus B': lambda B, C: C - B,
             'greet': 'Hello',
             'msg': lambda greet, A: '{} World! The answer is {}.'.format(greet, A),
         }

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -180,7 +180,7 @@ class ModelTest(unittest.TestCase):
 
         # cannot use async solver here because C won't be
         # pickable from pyunit
-        _ = afx.build()['counter']()
+        _ = afx.build()['counter']
         self.assertEqual(C.counter, 1)
 
     def test_at_constructor(self):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,14 @@
+from artifax.utils import arglist
+
+def test_arglist():
+
+    def f(foo, bar, bat):
+        print(foo, bar, bat)
+
+    def wrapper(*args):
+        f(*args)
+
+    import functools
+    functools.update_wrapper(wrapper, f)
+
+    assert set(arglist(f)) == set(arglist(wrapper))


### PR DESCRIPTION
Use inspect.signature instead of inspect.getfullargspec in artifax.utils.arglist, because inspect.getfullargspec is deprecated, and inspect.signature support functools.wrap utility.