### PR TITLE
build(): When targets is a unary list, return a unary tuple

### DIFF
--- a/artifax/models.py
+++ b/artifax/models.py
@@ -112,6 +112,7 @@ class Artifax:
                 Throws InvalidSolverError if solver is not among the available options.
             **kwargs: Arbitrary keyword arguments that are solver-specific.
         """
+        return_bare_result = isinstance(targets, str)
         targets = (targets,) if isinstance(targets, str) else targets
         if targets:
             for target in targets:
@@ -137,7 +138,7 @@ class Artifax:
             return self._result
 
         payload = tuple(self._result[target] for target in targets)
-        return payload if len(payload) > 1 else payload[0]
+        return payload[0] if return_bare_result else payload
 
     def initial(self):
         """Returns the initial objects of the artifacts graph, that is,

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -290,7 +290,7 @@ def test_build_with_underscore_in_key_name():
 def test_targeted_build_with_underscode_in_key_name():
     afx = Artifax({"b": lambda a_snake: a_snake})
     afx.set(a_snake=123)
-    assert afx.build(targets=["b"]) == 123
+    assert afx.build(targets="b") == 123
 
     afx = Artifax(
         {
@@ -299,4 +299,14 @@ def test_targeted_build_with_underscode_in_key_name():
         }
     )
     afx.set(a=123)
-    assert afx.build(targets=["b"]) == 123
+    assert afx.build(targets="b") == 123
+
+
+def test_string_targeted_build_returns_bare_result():
+    afx = Artifax({"a": 10, "b": 20})
+    assert afx.build(targets="a") == 10
+
+
+def test_unary_list_targeted_build_returns_tuple():
+    afx = Artifax({"a": 10, "b": 20})
+    assert afx.build(targets=["a"]) == (10,)


### PR DESCRIPTION
Hi there,

I’d like to propose this subtle but breaking change in behavior. In our library which consumes artifax, we have an optional `targets` parameter, which is either a list or None.

We pass this list into Artifax, and it would be helpful if Artifax behaved the same regardless of the length of that list.

The current behavior is that `build(targets=[“a”, “b”])` returns a tuple, while `build(targets=[“a”])` and `build(targets=“a”)` return a bare result.

With this change, a list of targets always returns a tuple of results. When the caller wants a bare result, pass `targets` as a string.

I think this is a nicer API for libraries which consume Artifax, providing more consistent behavior, without any loss of caller convenience in the unary case.

Thanks for considering! If you’d like to see how we’re using this, I’m happy to share in more detail.